### PR TITLE
Update wiringPiI2C.c

### DIFF
--- a/wiringPi/wiringPiI2C.c
+++ b/wiringPi/wiringPiI2C.c
@@ -228,7 +228,7 @@ int wiringPiI2CSetup (const int devId)
   else if (rev == 2)
    device = "/dev/i2c-1" ;
   else if (rev == 3)
-    device = "/dev/i2c-0"; // guenter fuer orange pi device = "/dev/i2c-2";
+    device = "/dev/i2c-2"; // guenter fuer orange pi device = "/dev/i2c-2";
 else
 	device = "/dev/i2c-3" ;
 


### PR DESCRIPTION
I use wiringPiI2C to work with the MPU6050 module and ran into a problem - the wiringPiI2CSetup function returned an error when initializing. I realized that my MPU6050 module is connected to "i2c-2" and the function can not pass the correct argument to the wiringPiI2CSetupInterface function.
I decided to use the wiringPiI2CSetupInterface function without wiringPiI2CSetup wrapper and it worked.